### PR TITLE
Add clang-12 and 13 to system.hpp

### DIFF
--- a/src/cn/system.hpp
+++ b/src/cn/system.hpp
@@ -31,6 +31,10 @@ static const struct System
 
   const std::string clang_binary = []() {
     using namespace std::literals;
+    if (auto p = get_executable_path("clang-13"))
+      return *p;
+    if (auto p = get_executable_path("clang-12"))
+      return *p;
     if (auto p = get_executable_path("clang-11"))
       return *p;
     if (auto p = get_executable_path("clang-10"))
@@ -47,6 +51,10 @@ static const struct System
   }();
   const std::string clangpp_binary = []() {
     using namespace std::literals;
+    if (auto p = get_executable_path("clang++-13"))
+      return *p;
+    if (auto p = get_executable_path("clang++-12"))
+      return *p;
     if (auto p = get_executable_path("clang++-11"))
       return *p;
     if (auto p = get_executable_path("clang++-10"))


### PR DESCRIPTION
I work on clang and dogfood it along the way and thus my toolchain of
choice is llvm-12 and will be llvm-13 come January. Might as well
support them now.