### PR TITLE
 Don't explicitly check for clang++, just use clang

### DIFF
--- a/src/cn/check.cpp
+++ b/src/cn/check.cpp
@@ -193,16 +193,16 @@ bool check_environment() noexcept
 
   const std::string clang_test_command =
 #if (_WIN32)
-      "echo int main(){} | " + sys.clangpp_binary + " -x c++ -stdlib=libc++ -fuse-ld=lld - -o nul"
+      "echo int main(){} | " + sys.clang_binary + " -x c++ -stdlib=libc++ -fuse-ld=lld - -o nul"
 #elif (__APPLE__)
-      "echo 'int main(){}' | " + sys.clangpp_binary + " -x c++ - -o /dev/null"
+      "echo 'int main(){}' | " + sys.clang_binary + " -x c++ - -o /dev/null"
 #else
-      "echo 'int main(){}' | " + sys.clangpp_binary
+      "echo 'int main(){}' | " + sys.clang_binary
       + " -x c++ -stdlib=libc++ -fuse-ld=lld - -o /dev/null"
 #endif
       ;
 
-  if (sys.clangpp_binary.empty() || !check_system_command(clang_test_command))
+  if (sys.clang_binary.empty() || !check_system_command(clang_test_command))
   {
     fmt::print(" ---------------------------------------------------------------- \n");
     if constexpr (sys.os_linux)

--- a/src/cn/system.hpp
+++ b/src/cn/system.hpp
@@ -49,25 +49,5 @@ static const struct System
       return *p;
     return ""s;
   }();
-  const std::string clangpp_binary = []() {
-    using namespace std::literals;
-    if (auto p = get_executable_path("clang++-13"))
-      return *p;
-    if (auto p = get_executable_path("clang++-12"))
-      return *p;
-    if (auto p = get_executable_path("clang++-11"))
-      return *p;
-    if (auto p = get_executable_path("clang++-10"))
-      return *p;
-    if (auto p = get_executable_path("clang++-9"))
-      return *p;
-    if (auto p = get_executable_path("clang++-8"))
-      return *p;
-    if (auto p = get_executable_path("clang++-7"))
-      return *p;
-    if (auto p = get_executable_path("clang++"))
-      return *p;
-    return ""s;
-  }();
 } sys;
 }

--- a/src/cn/system.hpp
+++ b/src/cn/system.hpp
@@ -31,6 +31,10 @@ static const struct System
 
   const std::string clang_binary = []() {
     using namespace std::literals;
+    if (auto p = get_executable_path("clang-13"))
+      return *p;
+    if (auto p = get_executable_path("clang-12"))
+      return *p;
     if (auto p = get_executable_path("clang-11"))
       return *p;
     if (auto p = get_executable_path("clang-10"))
@@ -47,6 +51,10 @@ static const struct System
   }();
   const std::string clangpp_binary = []() {
     using namespace std::literals;
+    if (auto p = get_executable_path("clang++-13"))
+      return *p;
+    if (auto p = get_executable_path("clang++-12"))
+      return *p;
     if (auto p = get_executable_path("clang++-11"))
       return *p;
     if (auto p = get_executable_path("clang++-10"))


### PR DESCRIPTION
Default llvm builds don't even create a `clang++-12` link. They create
clang-12, clang and clang++ links. In this case just use clang-12 since
the usages are passing `-x c++` anyways.